### PR TITLE
Set height of table to 98% of viewport size (98vh)

### DIFF
--- a/OutTabulatorView.psm1
+++ b/OutTabulatorView.psm1
@@ -35,6 +35,7 @@ function Out-TabulatorView {
         }
 
         $tabulatorColumnOptions = @{}
+        $tabulatorColumnOptions['height'] = "98vh"
         $tabulatorColumnOptions.columns = @()
 
         foreach ($name in $names) {


### PR DESCRIPTION
This fixes the issue #11 that I had with this module.

By setting the table height for Tabulator then it can maintain the scrollbars in view and also the added benefit of the data rendering faster as it only needs to render the data on screen, not the entire table. In the Tabulator documentation it is recommended to set the height to avoid performance issues.
I have set the height to 98vh meaning 98% of the browser window size, had to go a bit lower as the scrollbar would be just out of view if set to 100.

This is just a quick fix, maybe it should be an option or something, you decide.

![outtabulatorview-hscrollbarfix](https://user-images.githubusercontent.com/26866146/51808710-d7f3dc80-2297-11e9-9782-df884568ca98.gif)


Tested on:
PSVersion                      6.2.0-preview.3
PSEdition                      Core
GitCommitId                    6.2.0-preview.3
OS                             Microsoft Windows 10.0.17763
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0

Browser: Google Chrome 71