### PR TITLE
Arrays

### DIFF
--- a/OutTabulatorView.psd1
+++ b/OutTabulatorView.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'OutTabulatorView.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.0'
+    ModuleVersion     = '1.2.0'
 
     # ID used to uniquely identify this module
     GUID              = '51c258c2-f49f-49e5-b6ed-05acf3d9ace6'

--- a/OutTabulatorView.psm1
+++ b/OutTabulatorView.psm1
@@ -17,12 +17,11 @@ function Out-TabulatorView {
     )
 
     Begin {
-        $htmlFileName = [system.io.path]::GetTempFileName() -replace "\.tmp", ".html"
-        $records = @()
+        $htmlFileName = [system.io.path]::GetTempFileName() -replace '\.tmp', '.html'
+        $records = New-Object System.Collections.Generic.List[System.Object]
     }
-
     Process {
-        $records += @($data)
+        $Data | Foreach-Object { $Records.Add( $_ ) }
     }
 
     End {
@@ -31,11 +30,12 @@ function Out-TabulatorView {
         $targetData = $records | ConvertTo-Json -Depth 2 -Compress
 
         if ($records.Count -eq $null -or $records.Count -eq 1) {
-            $targetData = "[{0}]" -f $targetData
+            $targetData = '[{0}]' -f $targetData
         }
 
         $tabulatorColumnOptions = @{}
-        $tabulatorColumnOptions.columns = @()
+        # $tabulatorColumnOptions.columns = @()
+        $tabulatorColumnOptions.columns = New-Object System.Collections.Generic.List[System.Object]
 
         foreach ($name in $names) {
             $targetColumn = @{field = $name}
@@ -46,17 +46,17 @@ function Out-TabulatorView {
                 }
             }
 
-            if (!$targetColumn.ContainsKey("title")) {
+            if (!$targetColumn.ContainsKey('title')) {
                 $targetColumn.title = $name
             }
 
-            $tabulatorColumnOptions.columns += $targetColumn
+            $tabulatorColumnOptions.columns.Add( $targetColumn )
         }
 
         $params = @{} + $PSBoundParameters
 
-        $params.Remove("columnOptions")
-        $params.Remove("data")
+        $params.Remove('columnOptions')
+        $params.Remove('data')
 
         foreach ($entity in $params.GetEnumerator()) {
             $tabulatorColumnOptions.($entity.Key) = $entity.Value
@@ -140,7 +140,7 @@ function New-ColumnOption {
     )
 
     $cn = $PSBoundParameters.ColumnName
-    $null = $PSBoundParameters.Remove("ColumnName")
+    $null = $PSBoundParameters.Remove('ColumnName')
 
     @{$cn = @{} + $PSBoundParameters}
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ PowerShell - Sending output to an interactive table in a browser
 
 Grab it from the [PowerShell Gallery](https://www.powershellgallery.com/packages/OutTabulatorView)
 
+# What's New 1.2.0
+
+Now handles large datasets much better thank you [RoYoMi](https://github.com/RoYoMi)!
+
+A 10k item dataset used to take ~2 seconds to load, now it sub second!
+
+```powershell
+
 # What's New 1.1.0
 
 - Thank you to [ViperTG](https://github.com/ViperTG) for the pull request : File encoding changed to UTF8 to support characters like `æøå`


### PR DESCRIPTION
### TL:DR
+= runs slower than a Generic List, with large datasets.

Swapped out double quotes with single quotes where variable expansion isn't needed for a minor performance increase.

### Details

I regularly work with data sets between 10k and 400k records. This pull request addresses a performance impact that happens in PowerShell before it's sent to the HTML file.

The performance difference is negligible with small record sizes. So either approach is fine. However, as the number of records increases. The processing time of a '+=' grows exponentially.

|Record Count|+= Milliseconds|Generic List Milliseconds|
|-|-|-|
|1k|39|60|
|4k|205|204|
|10k|1500|500|
|100k|187000|4000|

### Example script
Here is how I tested the performance.
It should be noted that my lab computer is slow. It only has 1 CPU with four 2.0 GHz cores, and 12gb of memory.

```
# adjust this range to process more or less records
$Data = 1..4000

function Test {
    param ( 
        [Parameter(ValueFromPipeline)]
        $data
        )
    Begin {
        $Records = @()
        }
    Process {
        $Records += @( $Data )
        }
    }
Measure-Command {
    $Data | Test
    } | Select-Object TotalMilliseconds


function Test {
    param ( 
        [Parameter(ValueFromPipeline)]
        $data
        )
    Begin {
        $records = New-Object System.Collections.Generic.List[System.Object]
        }
    Process {
        $Data | Foreach-Object { $Records.Add( $_ ) }
        }
    }
Measure-Command {
    $Data | Test
    } | Select-Object TotalMilliseconds
```



